### PR TITLE
Test log overflow with both mkdir and mkfile

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -15,6 +15,8 @@ include_directories("${PROJECT_SOURCE_DIR}/usr")
 include_directories("${PROJECT_SOURCE_DIR}/../kmod")
 include_directories("${PROJECT_SOURCE_DIR}/testlib")
 
+add_library(famfs_unit_testlib famfs_unit.c)
+
 #file(GLOB sources "${PROJECT_SOURCE_DIR}/src/test/*.c")
 #list(REMOVE_ITEM sources "${PROJECT_SOURCE_DIR}/src/main.c")
 
@@ -32,7 +34,7 @@ foreach(file ${tests})
     ${file}
     )
 #    "${PROJECT_SOURCE_DIR}/test/main.cpp")
-  target_link_libraries("${name}_tests" gtest_main libfamfs famfstest uuid )
+  target_link_libraries("${name}_tests" gtest_main libfamfs famfstest uuid famfs_unit_testlib )
   message(STATUS "name=${name}")
   add_test(NAME ${name} COMMAND "${name}_tests")
 
@@ -45,7 +47,7 @@ foreach(file ${tests})
       setup_target_for_coverage_gcovr_html(
 	NAME "${name}_coverage"
 	EXECUTABLE "${name}_tests"
-	DEPENDENCIES gtest_main libfamfs
+	DEPENDENCIES gtest_main libfamfs famfstest famfs_unit_testlib
 	#BASE_DIRECORY "../"
       )
     endif()

--- a/test/famfs_unit.c
+++ b/test/famfs_unit.c
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2023-2024 Micron Technology, Inc.  All rights reserved.
+ */
+
+#include <unistd.h>
+#include <linux/limits.h>
+#include <sys/mman.h>
+#include <sys/stat.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "famfs_lib.h"
+#include "famfs_lib_internal.h"
+#include "famfs_meta.h"
+#include "famfs_unit.h"
+
+#define famfs_assert_eq(a, b) {						\
+	if ((a) != (b))	{						\
+		fprintf(stderr, "%s:%d %lld != %lld\n",			\
+		   __FILE__, __LINE__, (u64)(a), (u64)(b));		\
+		return __LINE__;					\
+	}								\
+}
+
+#define famfs_assert_gt(a, b) {						\
+	 if ((a) <= (b))	{					\
+		 fprintf(stderr, "%s:%d %lld !<= %lld\n",		\
+			 __FILE__, __LINE__, (u64)(a), (u64)(b));	\
+		 return __LINE__;					\
+	 }								\
+}
+
+#define famfs_assert_ne(a, b) {						\
+	if ((a) == (b)) {						\
+		fprintf(stderr, "%s:%d %lld == %lld\n",			\
+			__FILE__, __LINE__, (u64)(a), (u64)(b));	\
+		return __LINE__;					\
+	}								\
+}
+
+int create_mock_famfs_instance(
+	const char *path,
+	u64 device_size,
+	struct famfs_superblock **sb_out,
+	struct famfs_log **log_out)
+{
+	char *buf  = (char *)calloc(1, FAMFS_LOG_LEN);
+	struct famfs_superblock *sb;
+	struct famfs_log *logp;
+	mode_t mode = 0777;
+	int lfd, sfd;
+	void *addr;
+	int rc;
+
+	system("rm -rf /tmp/famfs");
+
+	/* Create fake famfs and famfs/.meta mount point */
+	rc = mkdir("/tmp/famfs", mode);
+	famfs_assert_eq(rc, 0);
+
+	rc = mkdir("/tmp/famfs/.meta", mode);
+	famfs_assert_eq(rc, 0);
+
+	/* Create fake log and superblock files */
+	sfd = open("/tmp/famfs/.meta/.superblock", O_RDWR | O_CREAT, 0666);
+	famfs_assert_gt(sfd, 0);
+	lfd = open("/tmp/famfs/.meta/.log", O_RDWR | O_CREAT, 0666);
+	famfs_assert_gt(lfd, 0);
+
+	/* Zero out the superblock and llog files */
+	rc = write(sfd, buf, FAMFS_SUPERBLOCK_SIZE);
+	famfs_assert_eq(rc, FAMFS_SUPERBLOCK_SIZE);
+
+	rc = write(lfd, buf, FAMFS_LOG_LEN);
+	famfs_assert_eq(rc, FAMFS_LOG_LEN);
+	
+	/* Mmap fake log file */
+	addr = mmap(0, FAMFS_SUPERBLOCK_SIZE, PROT_READ | PROT_WRITE, MAP_SHARED, sfd, 0);
+	famfs_assert_ne(addr, MAP_FAILED);
+	sb = (struct famfs_superblock *)addr;
+	*sb_out = sb;
+
+	famfs_dump_super(sb); /* dump invalid superblock */
+
+	/* mmap fake superblock file */
+	addr = mmap(0, FAMFS_LOG_LEN, PROT_READ | PROT_WRITE, MAP_SHARED, lfd, 0);
+	famfs_assert_ne(addr, MAP_FAILED);
+	logp = (struct famfs_log *)addr;
+	*log_out = logp;
+
+	famfs_dump_log(logp); /* dump invalid superblock */
+
+	memset(sb, 0, FAMFS_SUPERBLOCK_SIZE);
+	memset(logp, 0, FAMFS_LOG_LEN);
+
+	/* First mkfs should succeed */
+	rc = __famfs_mkfs("/dev/dax0.0", sb, logp, device_size, 0, 0);
+	famfs_assert_eq(rc, 0);
+
+	close(lfd);
+	close(sfd);
+	return 0;
+}
+

--- a/test/famfs_unit.h
+++ b/test/famfs_unit.h
@@ -1,0 +1,13 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/*
+ * Copyright (C) 2023-2024 Micron Technology, Inc.  All rights reserved.
+ */
+
+#ifndef FAMFS_UNIT_H
+#define FAMFS_UNIT_H
+
+int create_mock_famfs_instance(const char *path, u64 device_size,
+			       struct famfs_superblock **sb_out,
+			       struct famfs_log **log_out);
+
+#endif


### PR DESCRIPTION
This tests log overflow with both mkdir and mkfile. Loop counts are exact, and will change if the log size changes, or if the log entry size changes. Perhaps we can generalize this better...