### PR TITLE
famfs mkdir: default to 0755 permissions

### DIFF
--- a/src/famfs_cli.c
+++ b/src/famfs_cli.c
@@ -1184,16 +1184,14 @@ famfs_mkdir_usage(int   argc,
 int
 do_famfs_cli_mkdir(int argc, char *argv[])
 {
-	int c;
-
-	mode_t mode = 0644;
-	char *dirpath   = NULL;
 	uid_t uid = geteuid();
 	gid_t gid = getegid();
-	int arg_ct = 0;
+	char *dirpath = NULL;
+	mode_t mode = 0755;
 	int parents = 0;
 	int verbose = 0;
-	mode_t current_umask;
+	int arg_ct = 0;
+	int c;
 
 	/* TODO: allow passing in uid/gid/mode on command line*/
 
@@ -1253,11 +1251,6 @@ do_famfs_cli_mkdir(int argc, char *argv[])
 		fprintf(stderr, "Must specify at least one dax device\n");
 		return -1;
 	}
-
-	/* This is horky, but OK for the cli */
-	current_umask = umask(0022);
-	umask(current_umask);
-	mode &= ~(current_umask);
 
 	dirpath  = argv[optind++];
 	if (parents)

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -1405,6 +1405,10 @@ __famfs_logplay(
 			if (skip_dir)
 				continue;
 
+			if (verbose)
+				printf("%s mkdir: %o %d:%d: %s \n", __func__,
+				       md->fc_mode, md->fc_uid, md->fc_gid, md->famfs_relpath);
+
 			snprintf(fullpath, PATH_MAX - 1, "%s/%s", mpt, md->famfs_relpath);
 			realpath(fullpath, rpath);
 			if (dry_run)


### PR DESCRIPTION
The execute bits are needed to allow non-owners to list directories

fixes #27 