### PR TITLE
Support concurrent run_smoke.sh runs

### DIFF
--- a/run_smoke.sh
+++ b/run_smoke.sh
@@ -24,11 +24,6 @@ if [ $? -ne 0 ]; then
     echo "Error: password-less sudo capability is required to run smoke tests"
 fi
 
-# Make sure famfs is not mounted
-
-if (( $(grep famfs /proc/mounts | grep -c $MPT) > 0)); then
-    sudo umount $MPT
-fi
 TEST_FUNCS=$SCRIPTS/test_funcs.sh
 if [ ! -f $TEST_FUNCS ]; then
     echo "Can't source $TEST_FUNCS"

--- a/scripts/test_funcs.sh
+++ b/scripts/test_funcs.sh
@@ -73,16 +73,14 @@ verify_not_mounted () {
     DEV=$1
     MPT=$2
     MSG=$3
-    grep -c $DEV /proc/mounts && fail "verify_not_mounted: $DEV in /proc/mounts ($MSG)"
-    grep -c $MPT /proc/mounts && fail "verify_not_mounted: $MPT in /proc/mounts ($MSG)"
+    findmnt -t famfs $MPT && fail "verify_not_mounted: famfs still mounted at $MPT"
 }
 
 verify_mounted () {
     DEV=$1
     MPT=$2
     MSG=$3
-    grep -c $DEV /proc/mounts || fail "verify_mounted: $DEV not in /proc/mounts ($MSG)"
-    grep -c $MPT /proc/mounts || fail "verify_mounted: $MPT not in /proc/mounts ($MSG)"
+    findmnt -t famfs $MPT || fail "verify_mounted: famfs not mounted at $MPT"
 }
 
 

--- a/smoke/prepare.sh
+++ b/smoke/prepare.sh
@@ -58,8 +58,11 @@ set -x
 
 sudo mkdir -p $MPT || fail "mkdir"
 
-# Make sure famfs is not currently mounted
-grep -c famfs /proc/mounts         && fail "famfs is currently mounted"
+# Make sure famfs is not mounted
+findmnt -t famfs $MPT
+if (( $? == 0 )); then
+    sudo umount $MPT
+fi
 
 # destroy famfs file system, if any
 ${MKFS} -h            || fail "mkfs -h should work"

--- a/smoke/test0.sh
+++ b/smoke/test0.sh
@@ -157,7 +157,7 @@ ${CLI} logplay                     && fail "logplay without MPT arg should fail"
 
 # Unmount and remount
 sudo $UMOUNT $MPT || fail "umount should succeed"
-grep -c famfs /proc/mounts         && fail "famfs is still mounted after umount attempt"
+findmnt -t famfs $MPT && fail "famfs is still mounted at $MPT after umount attempt"
 
 sudo mount $MOUNT_OPTS $DEV $MPT   || fail "mount"
 


### PR DESCRIPTION
You can now run concurrently as follows:

DEV=/dev/dax1.0 MPT=/mnt/famfs ./run_smoke.sh
DEV=/dev/dax0.0 MPT=/mnt/fmlfs ./run_smoke.sh

smoke_loop.sh also works...

fixes #1 