### PR TITLE
Preparations for kernel patch set v2

### DIFF
--- a/run_smoke.sh
+++ b/run_smoke.sh
@@ -12,7 +12,7 @@ if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi
 if [ -z "$DEV" ]; then
-    DEV="/dev/pmem0"
+    DEV="/dev/dax0.0"
 fi
 if [ -z "$ERRS" ]; then
     ERRS=1

--- a/scripts/mkfs.sh
+++ b/scripts/mkfs.sh
@@ -22,7 +22,7 @@ echo "BIN $BIN"
 echo "SCRIPTS $SCRIPTS"
 
 # Defaults
-DEV="/dev/pmem0"
+DEV="/dev/dax0.0"
 VG=""
 MPT=/mnt/famfs
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "

--- a/scripts/mount.sh
+++ b/scripts/mount.sh
@@ -22,7 +22,7 @@ echo "BIN $BIN"
 echo "SCRIPTS $SCRIPTS"
 
 # Defaults
-DEV="/dev/pmem0"
+DEV="/dev/dax0.0"
 VG=""
 MPT=/mnt/famfs
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -36,7 +36,6 @@ sudo modprobe famfs  || fail "modprobe"
 
 verify_not_mounted $DEV $MPT "Already mounted"
 full_mount $DEV $MPT "setup: mount"
-#sudo mount -t famfs -o noatime -o dax=always /dev/pmem0 $MPT || fail "mount"
 verify_mounted $DEV $MPT "mount failed"
 
 set +x

--- a/scripts/test_funcs.sh
+++ b/scripts/test_funcs.sh
@@ -1,13 +1,6 @@
 
 # This file is not for running, it is for sourcing into other scripts
 
-#
-# Set to "char" if you convert the /dev/pmem device to a char dax device
-# (e.g. /dev/dax0.0). As of this typing, this is not working yet for complex
-# reasons)
-#
-
-
 fail () {
     set +x
     echo

--- a/smoke/prepare.sh
+++ b/smoke/prepare.sh
@@ -3,13 +3,16 @@
 cwd=$(pwd)
 
 # Defaults
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test0.sh
+++ b/smoke/test0.sh
@@ -3,13 +3,16 @@
 cwd=$(pwd)
 
 # Defaults
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test1.sh
+++ b/smoke/test1.sh
@@ -3,13 +3,16 @@
 cwd=$(pwd)
 
 # Defaults running from the directory where this file lives
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test2.sh
+++ b/smoke/test2.sh
@@ -3,13 +3,16 @@
 cwd=$(pwd)
 
 # Defaults
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test3.sh
+++ b/smoke/test3.sh
@@ -3,13 +3,16 @@
 cwd=$(pwd)
 
 # Defaults
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test4.sh
+++ b/smoke/test4.sh
@@ -68,22 +68,8 @@ ${CLI} creat -s 3g  ${MPT}/memfile       || fail "can't create memfile for multi
 ${CLI} creat -s 100m ${MPT}/memfile1     || fail "creat should succeed with -s 100m"
 ${CLI} creat -s 10000k ${MPT}/memfile2   || fail "creat with -s 10000k should succeed"
 
-# Let's count the faults during the multichase run
-sudo sh -c "echo 1 > /sys/fs/famfs/fault_count_enable"
-
 ${MULTICHASE} -d ${MPT}/memfile -m 2900m || fail "multichase fail"
 
-set +x
-echo -n "pte faults:"
-sudo cat /sys/fs/famfs/pte_fault_ct || fail "cat pte_fault_ct"
-echo
-echo -n "pmd faults: "
-sudo cat /sys/fs/famfs/pmd_fault_ct || fail "cat pmd_fault_ct"
-echo
-echo -n "pud faults: "
-sudo cat /sys/fs/famfs/pud_fault_ct || fail "cat pud_fault_ct"
-echo
-set -x
 verify_mounted $DEV $MPT "test4.sh mounted"
 sudo $UMOUNT $MPT || fail "test4.sh umount"
 verify_not_mounted $DEV $MPT "test4.sh"

--- a/smoke/test4.sh
+++ b/smoke/test4.sh
@@ -3,13 +3,16 @@
 cwd=$(pwd)
 
 # Defaults
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts/
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 RMMOD=0
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test_errors.sh
+++ b/smoke/test_errors.sh
@@ -3,12 +3,15 @@
 cwd=$(pwd)
 
 # Defaults
-DEV="/dev/pmem0"
 VG=""
 SCRIPTS=../scripts
 MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi

--- a/smoke/test_pcq.sh
+++ b/smoke/test_pcq.sh
@@ -9,15 +9,15 @@ MOUNT_OPTS="-t famfs -o noatime -o dax=always "
 BIN=../debug
 VALGRIND_ARG="valgrind --leak-check=full --show-leak-kinds=all --track-origins=yes"
 
-# These can be overridden via the environment
+# Allow these variables to be set from the environment
+if [ -z "$DEV" ]; then
+    DEV="/dev/dax0.0"
+fi
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
 fi
 if [ -z "$UMOUNT" ]; then
     UMOUNT="umount"
-fi
-if [ -z "$DEV" ]; then
-    DEV="/dev/pmem0"
 fi
 
 # Override defaults as needed


### PR DESCRIPTION
* Don't reference fault counters in smoke tests; these are going away
* Default device is not /dev/dax0.0, as /devpmem support is going away

We will be needing a new test that verifies that vma faults are handled at huge page granularity (see #12), but that is not currently urgent.