### PR TITLE
famfs: Do not remove the famfs module at the end of stress test.

### DIFF
--- a/run_stress_tests.sh
+++ b/run_stress_tests.sh
@@ -105,7 +105,6 @@ $SCRIPTS/stress_fio.sh -d $DEV -f $FIO_PATH -r $RUNTIME || echo "Fio stress test
 echo ""
 echo "Unmounting the filesystem and removing Famfs kernel module"
 sudo umount $MPT
-sudo rmmod famfs
 echo "*************************************************************************************"
 echo "                    run_stress_tests.sh completed"
 echo "*************************************************************************************"


### PR DESCRIPTION
When running multiple instances of the fio test if the module is removed by one instance, it will affect other running instances. So do not remove the modules.