### PR TITLE
famfs/stress: Update fio stress test

### DIFF
--- a/run_stress_tests.sh
+++ b/run_stress_tests.sh
@@ -8,6 +8,8 @@ TEST_ALL=1
 SLEEP_TIME=2
 RUNTIME=60
 FIO_PATH=""
+SIZE=0  # Amount of space to consume for files, 100% if no user input
+NJOBS=0 # Use all cpus for jobs if 0
 
 # Allow these variables to be set from the environment
 if [ -z "$MPT" ]; then
@@ -48,12 +50,16 @@ while (( $# > 0)); do
             BIN="$CWD/debug"
             echo "debug BIN=$BIN"
             ;;
-        (-c|--coverage)
-            BIN="$CWD/coverage"
-            echo "coverage BIN=$BIN"
-            ;;
         (-r|--runtime)
             RUNTIME=$1
+	    shift;
+            ;;
+        (-s|--size) # Amount of space to be used by this test
+            SIZE=$1
+	    shift;
+            ;;
+        (-j|--jobs) # Number of jobs/cpu to be used by this test
+            NJOBS=$1
 	    shift;
             ;;
         *)
@@ -97,14 +103,11 @@ fi
 
 $SCRIPTS/stress_prepare.sh -d $DEV  || exit -1
 
-# For now just run fio, when adding new stress tests, update the infra on how to call them
-#$SCRIPTS/stress_fio.sh -b $BIN -s $SCRIPTS -d $DEV -f $FIO_PATH -r $RUNTIME || exit -1
+# For now just run fio, when adding new stress tests, update the infra to call them
 
-$SCRIPTS/stress_fio.sh -d $DEV -f $FIO_PATH -r $RUNTIME || echo "Fio stress test  failed"
+$SCRIPTS/stress_fio.sh -d $DEV -f $FIO_PATH -r $RUNTIME -s $SIZE -j $NJOBS || echo "Fio stress test failed"
 
 echo ""
-echo "Unmounting the filesystem and removing Famfs kernel module"
-sudo umount $MPT
 echo "*************************************************************************************"
 echo "                    run_stress_tests.sh completed"
 echo "*************************************************************************************"

--- a/scripts/stress_fio.sh
+++ b/scripts/stress_fio.sh
@@ -9,6 +9,8 @@ DEV="/dev/dax0.0"
 SCRIPTS=$CWD/scripts
 BIN=$CWD/release
 RUNTIME=60
+TWO_MB=$((2*1024*1024))
+NJOBS=0
 
 if [ -z "$MPT" ]; then
     MPT=/mnt/famfs
@@ -34,12 +36,16 @@ while (( $# > 0)); do
             BIN=$1
             shift
             ;;
-        (-s|--scripts)
-            SCRIPTS=$1
-            shift;
-            ;;
         (-r|--runtime)
             RUNTIME=$1
+            shift;
+            ;;
+        (-s|--size)
+            SIZE=$1
+            shift;
+            ;;
+        (-j|--jobs)
+            NJOBS=$1
             shift;
             ;;
         *)
@@ -56,64 +62,92 @@ echo "SCRIPTS:  $SCRIPTS"
 
 source $SCRIPTS/test_funcs.sh
 
-NPROC=$(cat /proc/cpuinfo | awk '/^processor/{print $3}' | wc -l)
-NJOBS=$((NPROC - 1))
+# If NJOBS is not specified, use all cpus
+if [[ $NJOBS -eq 0 ]]; then
+    NPROC=$(cat /proc/cpuinfo | awk '/^processor/{print $3}' | wc -l)
+    NJOBS=$((NPROC - 1))
+fi
 
 # Get the device node name, ex: dax0.0 from /dev/dax0.0
 DEVICE=$(echo $DEV | awk -F '/' '{print $3}')
+
 # Get device size in bytes from sysfs, this works only for dax devices.
 DEV_SIZE_BYTES=$(cat /sys/bus/dax/devices/$DEVICE/size)
-
 FILES_PER_THRD=8
 TOTAL_FILE_COUNT=$((NJOBS * FILES_PER_THRD))
-TWO_MB=$((2*1024*1024))
+
 # Reserve 32MiB for metadata and log (for now, this is more than needed)
 RESRV_SPACE=$((32*1024*1024))
+
 # Usable device capacity
 DEV_SIZE=$((DEV_SIZE_BYTES - RESRV_SPACE))
-# Individual file size
-F_SIZE=$((DEV_SIZE / TOTAL_FILE_COUNT))
 
-# 2MiB aligned file size
-FILE_SIZE=$(((F_SIZE / TWO_MB) * TWO_MB))
+if [[ $SIZE -gt $DEV_SIZE ]]; then
+    echo "Error: Test size $SIZE greater than device size $DEV_SIZE_BYTES"
+    exit 0
+fi
+
+# If size is not specified, use the full available capacity
+if [[ $SIZE -eq 0 ]]; then
+    echo "User specified size is 0, using full usable device capacity"
+    SIZE=$DEV_SIZE
+fi
+
+# Famfs files take up 2MB at minmum
+MAX_FILES=$((SIZE / TWO_MB))
+echo "MAX_FILES for this test size = $MAX_FILES"
+if [[ $TOTAL_FILE_COUNT -gt $MAX_FILES ]]; then
+    FILES_PER_THRD=$((MAX_FILES / NJOBS))
+    TOTAL_FILE_COUNT=$((NJOBS * FILES_PER_THRD))
+
+    echo "Total files $((NJOBS * FILES_PER_THRD)) is more than max files possible $MAX_FILES for given size $SIZE"
+    echo "Updating Total files to $TOTAL_FILE_COUNT and Files per thread to $FILES_PER_THRD"
+fi
+
+# Individual file size
+F_SIZE=$((SIZE / TOTAL_FILE_COUNT))
+FSIZE_2M_A=$F_SIZE
+
+# 2MiB aligned file size in bytes
+if [[ $F_SIZE -gt $TWO_MB ]]; then
+    FSIZE_2M_A=$(((F_SIZE / TWO_MB) * TWO_MB))
+fi
 
 # Just to track if any space is wasted due to alignment
-WASTAGE=$(((DEV_SIZE - (TOTAL_FILE_COUNT  * FILE_SIZE)) / 1024))
+WASTAGE=$(((SIZE - (TOTAL_FILE_COUNT  * FSIZE_2M_A)) / 1024))
+
 # Individual file size in MiB
-FSIZE_MB=$((FILE_SIZE / (1024*1024)))
+FSIZE_MB=$((FSIZE_2M_A / (1024*1024)))
+
+if [[ $FSIZE_2M_A == 0 ]]; then
+    echo "Error: Cannot create $FSIZE_MB size files"
+    exit 0
+fi
 
 NAME="$FILES_PER_THRD-$FSIZE_MB-MB-files-per-thread"
 
-echo "Full device size  : $DEV_SIZE_BYTES"
-echo "Usable device size: $DEV_SIZE"
-echo "Number of jobs    : $NJOBS"
-echo "Files per job     : $FILES_PER_THRD"
-echo "File size (MiB)   : $FSIZE_MB"
-echo "Runtime           : $RUNTIME" 
+PID=$$
+FILES_DIR=$MPT/test_$PID
 
-#echo "last_proc=$last_proc"
-
-if [[ $FSIZE_MB == 0 ]]; then
-    echo "stress_fio.sh: Cannot create $FSIZE_MB size files "
-    exit 0
-fi
+#echo "Creating directory $MPT/$PID"
+echo "Creating directory $FILES_DIR"
+sudo $BIN/famfs mkdir $FILES_DIR
 
 for (( cpu = 0; cpu < $NJOBS; cpu++ ))
 do
     for (( fnum = 0; fnum < $FILES_PER_THRD; fnum++ ))
     do
         fname="$NAME.$cpu.$fnum"
-        echo "Creating famfs file $MPT/$fname"
-        sudo $BIN/famfs creat -v -s $FILE_SIZE $MPT/$fname || fail "failed to create file $fname"
+        echo "Creating famfs file $FILES_DIR/$fname"
+        sudo $BIN/famfs creat -v -s $FSIZE_2M_A $FILES_DIR/$fname || fail "failed to create file $fname"
     done
 done
 
-#sudo chown jmg:jmg $MPT/ten*
-
 echo "Running fio for $RUNTIME seconds"
 echo "fio --name=$NAME  --nrfiles=$FILES_PER_THRD --bs=2M --group_reporting=1 "
-echo "    --alloc-size=1048576 --filesize=$FILE_SIZE --readwrite=write --fallocate=none "
-echo "    --numjobs=$NJOBS --create_on_open=0 --directory=$MPT --time_based --runtime=$RUNTIME"
+echo "    --alloc-size=1048576 --filesize=$FSIZE_2M_A --readwrite=write --fallocate=none "
+echo "    --numjobs=$NJOBS --create_on_open=0 --directory=$FILES_DIR --time_based --runtime=$RUNTIME"
+echo ""
 
 #FIO_OUTPUT=$(sudo /usr/local/Repos/Fio/fio/fio -name=$NAME \
 FIO_OUTPUT=$(sudo $FIO_PATH -name=$NAME \
@@ -121,17 +155,32 @@ FIO_OUTPUT=$(sudo $FIO_PATH -name=$NAME \
     --bs=2M \
     --group_reporting=1 \
     --alloc-size=1048576 \
-    --filesize=$FILE_SIZE \
+    --filesize=$FSIZE_2M_A \
     --readwrite=write \
     --fallocate=none \
     --numjobs=$NJOBS \
     --create_on_open=0 \
-    --directory=$MPT \
+    --directory=$FILES_DIR \
     --time_based \
     --runtime=$RUNTIME | tee /dev/fd/2; exit ${PIPESTATUS[0]}) || exit 1
     #--runtime=$RUNTIME) || fail "fio failed"
 
 #echo "$FIO_OUTPUT"
+
+echo ""
+echo "Full device size      : $DEV_SIZE_BYTES"
+echo "Usable device size    : $DEV_SIZE"
+echo "User give size        : $SIZE"
+echo "Number of jobs        : $NJOBS"
+echo "Files per job         : $FILES_PER_THRD"
+echo "Total files           : $TOTAL_FILE_COUNT"
+echo "File size (Bytes)     : $F_SIZE"
+echo "2 MiB aligned fsize   : $FSIZE_2M_A"
+echo "File size (MiB)       : $FSIZE_MB MB"
+echo "Runtime               : $RUNTIME"
+echo "Size of all files     : $((FSIZE_2M_A * TOTAL_FILE_COUNT))"
+echo "Files location        : $FILES_DIR"
+echo ""
 
 echo "*************************************************************************************"
 echo "                    stress_fio.sh completed successfully"


### PR DESCRIPTION
Updated the fio stress test to run based on a specified size and cpu count such that other stress tests can also be run in parallel on the same device/host. Now the test can control how much device capacity (size) and how many cpus(jobs) should be used for this test. It also creates a subdir(based on pid) for each test so that more than one test can be run and the files of each test are isolated from one another.

To run the stress test:
Option 1:
_**make stress_tests**_  <== runs fio test for 60 mins on /dev/dax0.0 

Option 2: (run "run_stress_tests.sh" with below options

**_sudo ./run_stress_tests.sh -d /dev/dax0.0 -f /usr/local/Repos/Fio/fio/fio -r 300 -s 4000000000 -j 2_**

-d : (Optional) Specify the dax device, if not specified assumes /dev/dax0.0 is available.
-f :  (Optional) Specify the full path to fio binary, if not specified, assumes fio is available in system path
-r : (Optional) Specify the runtime for fio to run, if not specified, runs for 60 secs
-s:  (Optional) Specify the size to use from device capacity, if not specified, uses full device capacity
-j : (Optional) Specify the number of jobs(#cpus) to use, if not specified, uses "number_of_cpu_in_system -1" jobs

Option 3: (To run more than one instance of fio test)

Run **_sudo ./scripts/stress_prepare.sh -d /dev/dax0.0_**   <= this sets up the filesystem
Run below tests in succession and logs are available in respective log files
**_sudo ./scripts/stress_fio.sh -d /dev/dax0.0 -r 300 -s 300000000 -j 8 | tee test1.log &
sudo ./scripts/stress_fio.sh -d /dev/dax0.0 -r 300 -s 400000000 -j 8 | tee test2.log &_**






