### PR TITLE
Increase Code coverage

### DIFF
--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -1270,12 +1270,6 @@ __famfs_logplay(
 
 	role = (client_mode) ? FAMFS_CLIENT : famfs_get_role(sb);
 
-	if (logp->famfs_log_magic != FAMFS_LOG_MAGIC) {
-		fprintf(stderr, "%s: log has bad magic number (%llx)\n",
-			__func__, logp->famfs_log_magic);
-		return -1;
-	}
-
 	if (famfs_validate_log_header(logp)) {
 		fprintf(stderr, "%s: invalid log header\n", __func__);
 		return -1;

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -3109,7 +3109,7 @@ __famfs_cp(
 	 * Make sure we can open and read the source file
 	 */
 	srcfd = open(srcfile, O_RDONLY, 0);
-	if (srcfd < 0) {
+	if (srcfd < 0 || mock_failure == MOCK_FAIL_OPEN) {
 		fprintf(stderr, "%s: unable to open srcfile (%s)\n", __func__, srcfile);
 		return 1;
 	}
@@ -3127,7 +3127,8 @@ __famfs_cp(
 	}
 
 	destp = mmap(0, srcstat.st_size, PROT_READ | PROT_WRITE, MAP_SHARED, destfd, 0);
-	if (destp == MAP_FAILED) {
+	if (destp == MAP_FAILED ||
+			mock_failure == MOCK_FAIL_MMAP) {
 		fprintf(stderr, "%s: dest mmap failed (%s) size %ld\n",
 			__func__, destfile, srcstat.st_size);
 		unlink(destfile);
@@ -3181,7 +3182,7 @@ __famfs_cp(
  *             function fill append basename(srcfile) to destfile to get a nonexistent file path
  * @verbose
  */
-static int
+int
 famfs_cp(struct famfs_locked_log *lp,
 	 const char              *srcfile,
 	 const char              *destfile,
@@ -3214,7 +3215,8 @@ famfs_cp(struct famfs_locked_log *lp,
 			/* Destination is directory;  get the realpath and append the basename
 			 * from the source
 			 */
-			if (realpath(destfile, destpath) == 0) {
+			if (realpath(destfile, destpath) == 0 ||
+					mock_failure == MOCK_FAIL_GENERIC) {
 				fprintf(stderr, "%s: failed to rationalize destath path (%s)\n",
 					__func__, destfile);
 				return 1;

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -3587,29 +3587,30 @@ famfs_clone(const char *srcfile,
 		return -1;
 	}
 	rc = stat(srcfullpath, &src_stat);
-	if (rc < 0) {
+	if (rc < 0 || mock_failure == MOCK_FAIL_GENERIC) {
 		fprintf(stderr, "%s: unable to stat srcfile %s\n", __func__, srcfullpath);
 		return -1;
 	}
 
 	/*
-	 * Need to confirm that both files are inn the same file system. Otherwise,
+	 * Need to confirm that both files are in the same file system. Otherwise,
 	 * the cloned extents will be double-invalid on the second file :(
 	 */
 	src_role = famfs_get_role_by_path(srcfile, &src_fs_uuid);
 	dest_role = famfs_get_role_by_path(destfile, &dest_fs_uuid);
-	if (src_role < 0) {
+	if (src_role < 0 || mock_failure == MOCK_FAIL_SROLE) {
 		fprintf(stderr, "%s: Error: unable to check role for src file %s\n",
 			__func__, srcfullpath);
 		return -1;
 	}
-	if (dest_role < 0) {
-		fprintf(stderr, "%s: Error: unable to check role for src file %s\n",
+	if (dest_role < 0 ) {
+		fprintf(stderr, "%s: Error: unable to check role for dest file %s\n",
 			__func__, destfile);
 		return -1;
 	}
 	if ((src_role != dest_role) ||
-	    memcmp(&src_fs_uuid, &dest_fs_uuid, sizeof(src_fs_uuid)) != 0) {
+	    memcmp(&src_fs_uuid, &dest_fs_uuid, sizeof(src_fs_uuid)) != 0 ||
+	    mock_failure == MOCK_FAIL_ROLE) {
 		fprintf(stderr,
 			"%s: Error: source and destination must be in the same file system\n",
 			__func__);
@@ -3621,18 +3622,17 @@ famfs_clone(const char *srcfile,
 	}
 	/* FAMFS_MASTER role now confirmed, and the src and destination are in the same famfs */
 
-	/*
-	 * Open source file and make sure it's a famfs file
-	 */
+	/* Open source file */
 	sfd = open(srcfullpath, O_RDONLY, 0);
-	if (sfd < 0) {
+	if (sfd < 0 || mock_failure == MOCK_FAIL_OPEN) {
 		fprintf(stderr, "%s: failed to open source file %s\n",
 			__func__, srcfullpath);
-		return -1;
-	}
-	if (__file_not_famfs(sfd)) {
-		fprintf(stderr, "%s: source file %s is not a famfs file\n",
-			__func__, srcfullpath);
+
+		/* close the sfd if control reached here due to a mock_failure */
+		if (sfd > 0 && mock_failure == MOCK_FAIL_OPEN) {
+			rc = -1;
+			goto err_out;
+		}
 		return -1;
 	}
 
@@ -3729,8 +3729,6 @@ err_out:
 		close(lfd);
 	if (sfd > 0)
 		close(sfd);
-	if (lfd > 0)
-		close(lfd);
 	if (dfd > 0)
 		close(dfd);
 	return rc;

--- a/src/famfs_lib_internal.h
+++ b/src/famfs_lib_internal.h
@@ -14,6 +14,21 @@ enum lock_opt {
 	NON_BLOCKING_LOCK,
 };
 
+enum mock_failure {
+	MOCK_FAIL_NONE = 0,
+	MOCK_FAIL_GENERIC,
+	MOCK_FAIL_LOG_MKDIR,
+	MOCK_FAIL_OPEN_SB,
+	MOCK_FAIL_READ_SB,
+	MOCK_FAIL_OPEN_LOG,
+	MOCK_FAIL_READ_LOG,
+	MOCK_FAIL_READ_FULL_LOG,
+	MOCK_FAIL_ROLE,
+	MOCK_FAIL_SROLE,
+	MOCK_FAIL_OPEN,
+	MOCK_FAIL_MMAP,
+};
+
 struct famfs_locked_log {
 	s64               devsize;
 	struct famfs_log *logp;
@@ -50,5 +65,9 @@ int famfs_fsck_scan(const struct famfs_superblock *sb, const struct famfs_log *l
 		    int human, int verbose);
 int famfs_create_sys_uuid_file(char *sys_uuid_file);
 int famfs_get_system_uuid(uuid_le *uuid_out);
+void famfs_print_role_string(int role);
+int famfs_validate_log_entry(const struct famfs_log_entry *le, u64 index);
+int famfs_cp(struct famfs_locked_log *lp, const char *srcfile, const char *destfile,
+		mode_t mode, uid_t uid, gid_t gid, int verbose);
 
 #endif /* _H_FAMFS_LIB_INTERNAL */


### PR DESCRIPTION
Added unit tests to increase code coverage
In cases where the error/branch was not directly reachable, used a mock variable to simulate the error.
Before adding these tests, 
![before](https://github.com/cxl-micron-reskit/famfs/assets/20333180/a1f94f71-4081-4e56-9d00-0a1ade80e81c)

After adding these tests.
![after](https://github.com/cxl-micron-reskit/famfs/assets/20333180/9cd07326-7a07-4bff-bfbc-f9ba2e603928)
