### PR TITLE
record the latest free bits to optimize bitmap traversal performance

### DIFF
--- a/src/famfs_lib_internal.h
+++ b/src/famfs_lib_internal.h
@@ -34,6 +34,7 @@ struct famfs_locked_log {
 	struct famfs_log *logp;
 	int               lfd;
 	u64               nbits;
+	u64               cur_pos;
 	u8               *bitmap;
 	char              mpt[PATH_MAX];
 };


### PR DESCRIPTION
https://github.com/cxl-micron-reskit/famfs/issues/68