### PR TITLE
Make famfs log length configurable

### DIFF
--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -723,7 +723,7 @@ famfs_mmap_superblock_and_log_raw(const char *devname,
 	assert(sbp); /* superblock pointer mandatory; logp optional */
 
 	if (log_size &&
-	    ((log_size < FAMFS_LOG_LEN) || (log_size & (0x200000 - 1)) )) {
+	    ((log_size < FAMFS_LOG_LEN) || (log_size & (log_size - 1)) )) {
 		fprintf(stderr, "%s: invalid log_size %lld\n", __func__, log_size);
 		return -EINVAL;
 	}
@@ -751,7 +751,7 @@ famfs_mmap_superblock_and_log_raw(const char *devname,
 
 	/* Map the log if requested.
 	 * * If log_size is nonzero, we mmap that size.
-	 * * If log_size == 0, we get the log size from the superrblock, and we only
+	 * * If log_size == 0, we get the log size from the superblock, and we only
 	 *   map the log if there is a valid superblock
 	 */
 	if (logp) {
@@ -3862,8 +3862,8 @@ __famfs_mkfs(const char              *daxdev,
 
 	/* Minimum log length is the FAMFS_LOG_LEN; Also, must be a power of 2 */
 	if (log_len & (log_len - 1) || log_len < FAMFS_LOG_LEN) {
-		fprintf(stderr, "%s: log length (%lld) not a 2MiB multiple\n",
-			__func__, log_len);
+		fprintf(stderr, "Error: log length (%lld) must be >=8 MiB and a power of 2",
+			log_len);
 		return -EINVAL;
 	}
 

--- a/src/famfs_lib.h
+++ b/src/famfs_lib.h
@@ -46,7 +46,7 @@ int famfs_clone(const char *srcfile, const char *destfile, int verbose);
 
 int famfs_mkdir(const char *dirpath, mode_t mode, uid_t uid, gid_t gid, int verbose);
 int famfs_mkdir_parents(const char *dirpath, mode_t mode, uid_t uid, gid_t gid, int verbose);
-int famfs_mkfs(const char *daxdev, int kill, int force);
+int famfs_mkfs(const char *daxdev, u64 log_len, int kill, int force);
 int famfs_check(const char *path, int verbose);
 
 void famfs_dump_log(struct famfs_log *logp);

--- a/src/famfs_lib_internal.h
+++ b/src/famfs_lib_internal.h
@@ -46,7 +46,7 @@ int __file_not_famfs(int fd);
 unsigned long famfs_gen_superblock_crc(const struct famfs_superblock *sb);
 unsigned long famfs_gen_log_header_crc(const struct famfs_log *logp);
 int __famfs_mkfs(const char *daxdev, struct famfs_superblock *sb, struct famfs_log *logp,
-		 u64 device_size, int force, int kill);
+		 u64 log_len, u64 device_size, int force, int kill);
 int __open_relpath(const char *path, const char *relpath, int read_only, size_t *size_out,
 		   char *mpt_out, enum lock_opt lockopt, int no_fscheck);
 int __famfs_cp(struct famfs_locked_log  *lp, const char *srcfile, const char *destfile,

--- a/src/famfs_meta.h
+++ b/src/famfs_meta.h
@@ -20,6 +20,8 @@
 
 #include "famfs.h"
 
+#define STATIC_ASSERT(cond, msg) typedef char static_assertion_##msg[(cond) ? 1 : -1]
+
 #define FAMFS_SUPER_MAGIC      0x87b282ff
 #define FAMFS_CURRENT_VERSION  46
 #define FAMFS_MAX_DAXDEVS      64
@@ -31,6 +33,9 @@
 #define FAMFS_SUPERBLOCK_MAX_DAXDEVS 1
 
 #define FAMFS_ALLOC_UNIT 0x200000 /* 2MiB allocation unit */
+
+STATIC_ASSERT(!(FAMFS_LOG_LEN & (FAMFS_LOG_LEN - 1)), FAMFS_LOG_LEN_must_be_power_of_2);
+STATIC_ASSERT(!(FAMFS_ALLOC_UNIT & (FAMFS_ALLOC_UNIT - 1)), FAMFS_ALLOC_UNIT_must_be_power_of_2);
 
 static inline size_t round_size_to_alloc_unit(u64 size)
 {

--- a/test/famfs_unit.c
+++ b/test/famfs_unit.c
@@ -97,7 +97,7 @@ int create_mock_famfs_instance(
 	memset(logp, 0, FAMFS_LOG_LEN);
 
 	/* First mkfs should succeed */
-	rc = __famfs_mkfs("/dev/dax0.0", sb, logp, device_size, 0, 0);
+	rc = __famfs_mkfs("/dev/dax0.0", sb, logp, FAMFS_LOG_LEN, device_size, 0, 0);
 	famfs_assert_eq(rc, 0);
 
 	close(lfd);

--- a/test/famfs_unit.cpp
+++ b/test/famfs_unit.cpp
@@ -468,18 +468,19 @@ TEST(famfs, famfs_log)
 	rc = famfs_init_locked_log(&ll, "/tmp/famfs", 1);
 	ASSERT_EQ(rc, 0);
 
-	for (i = 0; i < 503; i++) {
+	for (i = 0; i < 512; i++) {
 		char filename[64];
 		int fd;
 		sprintf(filename, "/tmp/famfs/%04d", i);
 		fd = __famfs_mkfile(&ll, filename, 0, 0, 0, 1048576, 0);
-		if (i < 502)
+		if (i < 507)
 			ASSERT_GT(fd, 0);
 		else
 			ASSERT_LT(fd, 0); /* out of space */
 		close(fd);
 	}
 
+	/* Although we're out of memory space, we can still make directories */
 	for (i = 0; i < 100; i++) {
 		char dirname[64];
 		sprintf(dirname, "/tmp/famfs/dir%04d", i);


### PR DESCRIPTION
This passes all existing tests; will do further testing, including adding coverage of setting the log length before merging this.