### PR TITLE
Features and fixes

### DIFF
--- a/scripts/test_funcs.sh
+++ b/scripts/test_funcs.sh
@@ -23,6 +23,19 @@ assert_equal() {
     fi
 }
 
+
+# Expects the values to be not equal, asserts if equal
+assert_ne() {
+    local a="$1"
+    local b="$2"
+    local msg="$3"
+
+    if (( a == b )); then
+        echo "assertion ($a == $b) failed: $msg"
+        exit 1
+    fi
+}
+
 assert_lt() {
     local a="$1"
     local b="$2"

--- a/smoke/stripe_test.sh
+++ b/smoke/stripe_test.sh
@@ -95,6 +95,8 @@ stripe_test () {
 	${CLI} creat  -C "$CHUNKSIZE" -N "$NSTRIPS" -B "$NBUCKETS" -s "$SIZE" "$file_name"
 	if [[ $? -ne 0 ]]; then
 	    echo "File creation failed on $file_name"
+	    # Assert if counter is 0 i.e. first interleaved file creation failed
+	    assert_ne $counter 0 "Failed to create any interleaved files"
 	    break
 	fi
 

--- a/src/famfs_alloc.c
+++ b/src/famfs_alloc.c
@@ -589,7 +589,7 @@ famfs_file_strided_alloc(
 	/* We currently only support one interleaved extent - hence index [0] */
 	fmap->ie[0].ie_nstrips = lp->interleave_param.nstrips;
 	fmap->ie[0].ie_chunk_size = lp->interleave_param.chunk_size;
-	//fmap->ie[0].ie_nbytes = size; /* make sure kernel checks this */
+	fmap->ie[0].ie_nbytes = size; /* make sure kernel checks this */
 	strips = fmap->ie[0].ie_strips;
 
 	/* Allocate our strips. If nstrips is <  nbuckets, we can tolerate some failures */

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -916,6 +916,7 @@ famfs_v2_set_file_map(
 
 			kie[i].ie_nstrips = ie->ie_nstrips;
 			kie[i].ie_chunk_size = ie->ie_chunk_size;
+			kie[i].ie_nbytes = ie->ie_nbytes;
 
 			if (ie->ie_nstrips > FAMFS_MAX_SIMPLE_EXTENTS) {
 				fprintf(stderr, "%s: strip list overflow (%lld) at ie %d\n",

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -3621,6 +3621,7 @@ famfs_cp_multi(
 	mode_t mode,
 	uid_t uid,
 	gid_t gid,
+	struct famfs_interleave_param *s,
 	int recursive,
 	int verbose)
 {
@@ -3708,6 +3709,16 @@ famfs_cp_multi(
 		free(dest_parent_path);
 		free(dirdupe);
 		return rc;
+	}
+
+	if (s) {
+		if (verbose)
+			printf("%s: overriding interleave_param defaults (nbuckets/nstrips/chunk)="
+			       "(%lld/%lld/%lld) with (%lld/%lld/%lld)\n", __func__,
+			       ll.interleave_param.nbuckets, ll.interleave_param.nstrips, ll.interleave_param.chunk_size,
+			       s->nbuckets, s->nstrips, s->chunk_size);
+
+		ll.interleave_param = *s;
 	}
 
 	for (i = 0; i < src_argc; i++) {

--- a/src/famfs_lib.h
+++ b/src/famfs_lib.h
@@ -47,8 +47,8 @@ int famfs_logplay(const char *mpt, int use_mmap,
 int famfs_mkfile(const char *filename, mode_t mode, uid_t uid, gid_t gid, size_t size,
 		 struct famfs_interleave_param *interleave_param, int verbose);
 
-int famfs_cp_multi(int argc, char *argv[],
-		   mode_t mode, uid_t uid, gid_t gid, int recursive, int verbose);
+int famfs_cp_multi(int argc, char *argv[], mode_t mode, uid_t uid, gid_t gid,
+		struct famfs_interleave_param *s, int recursive, int verbose);
 int famfs_clone(const char *srcfile, const char *destfile, int verbose);
 
 int famfs_mkdir(const char *dirpath, mode_t mode, uid_t uid, gid_t gid, int verbose);


### PR DESCRIPTION
This PR has 4 commits.
1. Fix a smoke bug, so that it reports if a file creation in striped mode fails.
2. Fix a bug in famfs creat code path to propagate the file size to kernel, file creation was failing without this value in kernel
3. Make famfs cp command to support striped files. Below example copies from /tmp/ location into famfs with chunksize 2M, strips=4, buckets=5.
    > Ex:   famfs cp -C 2M -N 4 -B 5 /tmp/10mbfiles/* /mnt/famfs/
4.  Add smoke test to create and copy striped files.