### PR TITLE
build: fix Clang compilation errors and warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,8 @@ target_compile_definitions(libmongoose
     PUBLIC MG_ENABLE_UNIX=1
 )
 
+add_subdirectory(testlib)
+
 add_executable(famfs src/famfs_cli.c)
 add_executable(mkfs.famfs src/mkfs.famfs.c)
 add_executable(pcq src/pcq.c)
@@ -234,7 +236,6 @@ add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
 
 enable_testing()
 
-add_subdirectory(testlib)
 add_subdirectory(test)
 
 include(ExternalProject)

--- a/src/famfs_cli.c
+++ b/src/famfs_cli.c
@@ -1340,7 +1340,7 @@ int
 do_famfs_cli_clone(int argc, char *argv[])
 {
 	int c;
-	int verbose = 0;
+	int verbose __attribute__((unused)) = 0;
 	char *srcfile = NULL;
 	char *destfile = NULL;
 	char srcfullpath[PATH_MAX];

--- a/src/famfs_fused.c
+++ b/src/famfs_fused.c
@@ -370,7 +370,7 @@ famfs_do_lookup(
 	struct stat st;
 	int parentfd;
 	int saverr;
-	int newfd;
+	int newfd = -1;
 	int res;
 
 	famfs_log(FAMFS_LOG_DEBUG,

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -1475,6 +1475,7 @@ famfs_mkmeta_standalone(
 		goto out;
 		break;
 	default:
+		break;
 	}
 
 	rc = __famfs_mkmeta_log(mpt, sb->ts_log_offset, sb->ts_log_len,

--- a/src/famfs_mount.c
+++ b/src/famfs_mount.c
@@ -946,6 +946,7 @@ famfs_mount_fuse(
 			goto out;
 			break;
 		default:
+			break;
 		}
 	}
 

--- a/test/famfs_unit.cpp
+++ b/test/famfs_unit.cpp
@@ -31,6 +31,8 @@ extern "C" {
 #include <fuse_lowlevel.h>
 #include "famfs_fused_icache.h"
 #include "famfs_fused.h"
+
+extern int mock_failure;
 }
 
 /****+++++++++++++++++++++++++++++++++++++++++++++
@@ -296,6 +298,7 @@ TEST(famfs, famfs_xrand64_tls)
 	struct xrand xr;
 
 	xrand_init(&xr, 42);
+	num = xrand64_tls();
 	ASSERT_NE(num, 0);
 	num = xrand64_tls();
 	ASSERT_NE(num, 0);
@@ -377,7 +380,6 @@ TEST(famfs, __famfs_cp)
 	u64 device_size = 1024 * 1024 * 256;
 	struct famfs_locked_log ll;
 	struct famfs_superblock *sb;
-	extern int mock_failure;
 	struct famfs_log *logp;
 	extern int mock_kmod, mock_fstype;
 	int rc;
@@ -743,7 +745,6 @@ TEST(famfs, famfs_log)
 	u64 device_size = 1024 * 1024 * 1024;
 	struct famfs_superblock *sb;
 	struct famfs_locked_log ll;
-	extern int mock_failure;
 	struct famfs_log *logp;
 	extern int mock_kmod;
 	extern int mock_role;
@@ -1087,7 +1088,6 @@ TEST(famfs, famfs_clone) {
 	struct famfs_locked_log ll;
 	struct famfs_superblock *sb;
 	struct famfs_log *logp;
-	extern int mock_failure;
 	extern int mock_role;
 	extern int mock_kmod;
 	char filename[PATH_MAX * 2];
@@ -1231,7 +1231,6 @@ TEST(famfs, famfs_cp) {
 	struct famfs_locked_log ll;
 	struct famfs_superblock *sb;
 	struct famfs_log *logp;
-	extern int mock_failure;
 	extern int mock_kmod;
 	char src[PATH_MAX * 2];
 	char dest[PATH_MAX * 2];


### PR DESCRIPTION
Building famfs with Clang fails:

  $ CC=clang CXX=clang++ make all
  error: redefinition of 'mock_failure' as different kind of symbol

This patch fixes compilation errors and warnings when building with Clang.

CMakeLists.txt:
  - Fix ordering: famfstest target was referenced before testlib subdirectory was added. Move add_subdirectory(testlib) before the executables that depend on it.

src/famfs_lib.c, src/famfs_mount.c:
  - Add missing break statement to empty default cases to fix "label at end of compound statement is a C23 extension" warning.

src/famfs_cli.c:
  - Mark unused 'verbose' variable with __attribute__((unused)) to suppress "variable set but not used" warning.

src/famfs_fused.c:
  - Initialize 'newfd' to -1 to fix "variable is used uninitialized whenever 'if' condition is true" warning.

test/famfs_unit.cpp:
  - Move 'extern int mock_failure' declaration into the extern "C" block at file scope. In C++, declaring 'extern int mock_failure' inside a function conflicts with 'enum mock_failure' defined in famfs_lib_internal.h because the variable and enum type share the same name.
  - Fix uninitialized variable 'num' warning by calling xrand64_tls() before the first ASSERT_NE check.