### PR TITLE
build: fix Clang compilation errors and warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,6 +170,8 @@ target_compile_definitions(libmongoose
     PUBLIC MG_ENABLE_UNIX=1
 )
 
+add_subdirectory(testlib)
+
 add_executable(famfs src/famfs_cli.c)
 add_executable(mkfs.famfs src/mkfs.famfs.c)
 add_executable(pcq src/pcq.c)
@@ -234,7 +236,6 @@ add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
 
 enable_testing()
 
-add_subdirectory(testlib)
 add_subdirectory(test)
 
 include(ExternalProject)

--- a/src/famfs_cli.c
+++ b/src/famfs_cli.c
@@ -1340,7 +1340,7 @@ int
 do_famfs_cli_clone(int argc, char *argv[])
 {
 	int c;
-	int verbose = 0;
+	int verbose __attribute__((unused)) = 0;
 	char *srcfile = NULL;
 	char *destfile = NULL;
 	char srcfullpath[PATH_MAX];

--- a/src/famfs_fused.c
+++ b/src/famfs_fused.c
@@ -370,7 +370,7 @@ famfs_do_lookup(
 	struct stat st;
 	int parentfd;
 	int saverr;
-	int newfd;
+	int newfd = -1;
 	int res;
 
 	famfs_log(FAMFS_LOG_DEBUG,

--- a/src/famfs_lib.c
+++ b/src/famfs_lib.c
@@ -1475,6 +1475,7 @@ famfs_mkmeta_standalone(
 		goto out;
 		break;
 	default:
+		break;
 	}
 
 	rc = __famfs_mkmeta_log(mpt, sb->ts_log_offset, sb->ts_log_len,

--- a/src/famfs_mount.c
+++ b/src/famfs_mount.c
@@ -946,6 +946,7 @@ famfs_mount_fuse(
 			goto out;
 			break;
 		default:
+			break;
 		}
 	}
 

--- a/test/famfs_unit.cpp
+++ b/test/famfs_unit.cpp
@@ -31,6 +31,8 @@ extern "C" {
 #include <fuse_lowlevel.h>
 #include "famfs_fused_icache.h"
 #include "famfs_fused.h"
+
+extern int mock_failure;
 }
 
 /****+++++++++++++++++++++++++++++++++++++++++++++
@@ -296,7 +298,6 @@ TEST(famfs, famfs_xrand64_tls)
 	struct xrand xr;
 
 	xrand_init(&xr, 42);
-	ASSERT_NE(num, 0);
 	num = xrand64_tls();
 	ASSERT_NE(num, 0);
 	num = xrand_range64(&xr, 42, 0x100000);
@@ -377,7 +378,6 @@ TEST(famfs, __famfs_cp)
 	u64 device_size = 1024 * 1024 * 256;
 	struct famfs_locked_log ll;
 	struct famfs_superblock *sb;
-	extern int mock_failure;
 	struct famfs_log *logp;
 	extern int mock_kmod, mock_fstype;
 	int rc;
@@ -743,7 +743,6 @@ TEST(famfs, famfs_log)
 	u64 device_size = 1024 * 1024 * 1024;
 	struct famfs_superblock *sb;
 	struct famfs_locked_log ll;
-	extern int mock_failure;
 	struct famfs_log *logp;
 	extern int mock_kmod;
 	extern int mock_role;
@@ -1087,7 +1086,6 @@ TEST(famfs, famfs_clone) {
 	struct famfs_locked_log ll;
 	struct famfs_superblock *sb;
 	struct famfs_log *logp;
-	extern int mock_failure;
 	extern int mock_role;
 	extern int mock_kmod;
 	char filename[PATH_MAX * 2];
@@ -1231,7 +1229,6 @@ TEST(famfs, famfs_cp) {
 	struct famfs_locked_log ll;
 	struct famfs_superblock *sb;
 	struct famfs_log *logp;
-	extern int mock_failure;
 	extern int mock_kmod;
 	char src[PATH_MAX * 2];
 	char dest[PATH_MAX * 2];


### PR DESCRIPTION
Fix compilation errors and warnings when building with Clang:

- CMakeLists.txt: move add_subdirectory(testlib) before targets that depend on it
- src/famfs_lib.c, src/famfs_mount.c: add break to empty default cases
- src/famfs_cli.c: suppress unused variable warning for verbose
- src/famfs_fused.c: initialize newfd to -1
- test/famfs_unit.cpp: move extern mock_failure to file scope and remove erroneous ASSERT_NE before variable initialization